### PR TITLE
Fix spelling of .eslintignore file name

### DIFF
--- a/src/ContentType/IgnoreContentTypeDefinition.cs
+++ b/src/ContentType/IgnoreContentTypeDefinition.cs
@@ -59,7 +59,7 @@ namespace IgnoreFiles
 
         [Export(typeof(FileExtensionToContentTypeDefinition))]
         [ContentType(IgnoreContentType)]
-        [FileExtension(".eslintegnore")]
+        [FileExtension(".eslintignore")]
         public FileExtensionToContentTypeDefinition EslintFileExtension { get; set; }
 
         [Export(typeof(FileExtensionToContentTypeDefinition))]


### PR DESCRIPTION
The `.eslintignore` string passed to the `FileExtension` attribute was spelled incorrectly.
