### PR TITLE
Add support for .babelignore file

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ or get the [CI build](http://vsixgallery.com/extension/7ac24965-ea21-4108-9cac-6
 This extension supports *.gitignore (Git), .tfignore (Team Foundation),
 .hgignore (Mercurial), .npmignore (npm), .dockerignore (Docker),
 .chefignore (Chef), .cvsignore (CVS), .bzrignore (Bazaar),
-.jshintignore (JSHint), .eslintignore (ESLint), .cfignore (Cloud Foundry)*
+.jshintignore (JSHint), .eslintignore (ESLint), .cfignore (Cloud Foundry),
+.babelignore (Babel)*
 
 See the [changelog](CHANGELOG.md) for changes and roadmap.
 

--- a/src/ContentType/IgnoreContentTypeDefinition.cs
+++ b/src/ContentType/IgnoreContentTypeDefinition.cs
@@ -66,5 +66,10 @@ namespace IgnoreFiles
         [ContentType(IgnoreContentType)]
         [FileExtension(".cfignore")]
         public FileExtensionToContentTypeDefinition CloudFoundryFileExtension { get; set; }
+
+        [Export(typeof(FileExtensionToContentTypeDefinition))]
+        [ContentType(IgnoreContentType)]
+        [FileExtension(".babelignore")]
+        public FileExtensionToContentTypeDefinition BabelFileExtension { get; set; }
     }
 }

--- a/src/ContentType/icons.pkgdef
+++ b/src/ContentType/icons.pkgdef
@@ -41,3 +41,7 @@
 // Cloud foundry
 [$RootKey$\ShellFileAssociations\.cfignore]
 "DefaultIconMoniker"="KnownMonikers.ExlcudeScript"
+
+// Babel
+[$RootKey$\ShellFileAssociations\.babelignore]
+"DefaultIconMoniker"="KnownMonikers.ExlcudeScript"


### PR DESCRIPTION
Per the official Babel docs [here](http://babeljs.io/docs/usage/options/), there is a `.babelignore` file. Here's an example of one: https://github.com/thejameskyle/babel-plugin-cli/blob/master/.babelignore. This PR adds support for that file name.
