### PR TITLE
Safeguard from parameter name change by using nameof

### DIFF
--- a/src/WpfUtil.cs
+++ b/src/WpfUtil.cs
@@ -92,7 +92,7 @@ namespace IgnoreFiles
 
         private static object GetObjectData(IVsUIObject obj)
         {
-            Validate.IsNotNull(obj, "obj");
+            Validate.IsNotNull(obj, nameof(obj));
 
             object value;
             int result = obj.get_Data(out value);


### PR DESCRIPTION
This PR makes use of the C# 6 `nameof` expression to replace a hard-coded parameter name. This makes the code a tad bit more elegant by removing a magic string.
